### PR TITLE
Travis experiments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - npm test # test the code
   - npm run build-client # make the bundle
 before_deploy: # omit node_modules, since we set skip_cleanup below
-  - npm run build-client
+  # - npm run build-client
   - rm -rf node_modules
 deploy: # see README for details on these keys
   # prevents travis from deleting the build

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "node server",
     "start-dev": "NODE_ENV='development' npm run build-client-watch & NODE_ENV='development' npm run start-server",
     "start-server": "nodemon server -e html,js,scss --ignore public --ignore client",
-    "test": "NODE_ENV='test' mocha --watch \"./server/**/*.spec.js\" \"./client/**/*.spec.js\" \"./script/**/*.spec.js\" --require @babel/polyfill --require @babel/register"
+    "test": "NODE_ENV='test' mocha \"./server/**/*.spec.js\" \"./client/**/*.spec.js\" \"./script/**/*.spec.js\" --require @babel/polyfill --require @babel/register"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
The reason travis built forever is because tests were watching, which while convenient for our purposes, meant in travis they never stopped and it could never build the webpack. If this is merged to master, fingers crossed, our app might build properly on heroku. It shouldn't break anything anyone else is doing anywhere. It is a two line change :)